### PR TITLE
Drop unsupported "version" from script type attr

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,4 +52,4 @@
 
   <p><a href="https://github.com/bsmedberg/firefox-regression-range-finder">View/fork me on github</a>. Contact <a href="http://benjamin.smedbergs.us/contact/">bsmedberg</a> if you have issues/questions.
 
-  <script src="regression-range.js" type="application/x-javascript;version=1.8"></script>
+  <script src="regression-range.js" type="application/x-javascript"></script>


### PR DESCRIPTION
Per https://bugzilla.mozilla.org/show_bug.cgi?id=1428745 , Firefox has dropped support for "version" strings inside the `<script ... type="">` attribute.  As a result, firefox-regression-range-finder's "regression-range.js" script is no longer executed, apparently.

Per https://bugzilla.mozilla.org/show_bug.cgi?id=1440338#c4 , the fix is to simply drop the "version=..." string from the type attribute.